### PR TITLE
feat(thirdparty-simulator): DFSP User Login and Authorization screens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,13 @@ defaults_build_docker_publish: &defaults_build_docker_publish
   command: |
     echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
     docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+    case "$CIRCLE_TAG" in
+      *-pisp*)
+        # Don't update `late5t` for an image that has a `-pisp`
+        echo 'skipping late5t tag'
+        exit 0
+        ;;
+      *)
     echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
     docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
 defaults_slack_announcement: &defaults_slack_announcement
@@ -396,7 +403,7 @@ workflows:
             - audit-licenses
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*?(\-pisp)?/
             branches:
               ignore:
                 - /.*/

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -2,15 +2,15 @@
   "decisions": {
     "1589|electron>@electron/get>global-tunnel-ng>npm-conf>config-chain>ini": {
       "decision": "postpone",
-      "madeAt": 1612284623327
+      "madeAt": 1612519716643
     },
     "1589|react-scripts>react-dev-utils>global-modules>global-prefix>ini": {
       "decision": "postpone",
-      "madeAt": 1612284623327
+      "madeAt": 1612519716643
     },
     "1594|axios": {
       "decision": "postpone",
-      "madeAt": 1612284624421
+      "madeAt": 1612519721326
     }
   },
   "rules": {},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - API_BASE_URL=http://localhost:5050
       - AUTH_ENABLED=FALSE
+      - PISP_3P_SIM_API_BASE_URL=http://ml-testing-toolkit.local:15000
     command:
       - sh
       - /usr/share/nginx/start.sh

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -4,4 +4,7 @@ fi
 if [[ ! -z "${AUTH_ENABLED}" ]]; then
     find /usr/share/nginx/html -type f -name "*.*" -exec sed -i -e "s|TTK_AUTH_ENABLED|$AUTH_ENABLED|g" {} \;
 fi
+if [[ ! -z "${PISP_3P_SIM_API_BASE_URL}" ]]; then
+    find /usr/share/nginx/html -type f -name "*.*" -exec sed -i -e "s|TTK_PISP_3P_SIM_API_BASE_URL|$PISP_3P_SIM_API_BASE_URL|g" {} \;
+fi
 nginx -g "daemon off;"

--- a/src/routes.js
+++ b/src/routes.js
@@ -31,6 +31,8 @@ import MonitorDiagram from "./views/monitor/MonitorDiagram.jsx";
 import Settings from "./views/settings/Settings.jsx";
 import APIManagement from "./views/apis/APIManagement.jsx";
 import Demos from "./views/demos/Demos.jsx";
+import DFSPAuthorize from "./views/thirdparty-simulator/DFSPAuthorize.jsx";
+import DFSPGrantConsent from "./views/thirdparty-simulator/DFSPGrantConsent.jsx";
 
 import {
   DashboardOutlined,
@@ -42,7 +44,9 @@ import {
   FileSyncOutlined,
   FileSearchOutlined,
   SendOutlined,
-  ExperimentOutlined
+  ExperimentOutlined,
+  LoginOutlined,
+  CheckCircleOutlined
 } from '@ant-design/icons';
 
 var routes = [
@@ -123,5 +127,19 @@ var routes = [
     component: Demos,
     layout: "/admin"
   },
+  {
+    path: "/dfsp/authorize",
+    name: "DFSP Authorize",
+    icon: <LoginOutlined />,
+    component: DFSPAuthorize,
+    layout: "/admin"
+  },
+  {
+    path: "/dfsp/grant-user-consent",
+    name: "DFSP Grant Consent",
+    icon: <CheckCircleOutlined />,
+    component: DFSPGrantConsent,
+    layout: "/admin"
+  }
 ];
 export default routes;

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -46,4 +46,9 @@ export const getServerConfig = async () => {
   return { userConfigRuntime, userConfigStored }
 }
 
+export const getThirdpartySimConfig = async () => {
+  const thirdpartySimAPIBaseUrl = 'TTK_PISP_3P_SIM_API_BASE_URL'
+  return { thirdpartySimAPIBaseUrl }
+}
+
 export default getConfig

--- a/src/views/thirdparty-simulator/DFSPAuthorize.jsx
+++ b/src/views/thirdparty-simulator/DFSPAuthorize.jsx
@@ -1,0 +1,101 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+import React from 'react';
+import axios from 'axios';
+import queryString from 'query-string';
+import { withRouter } from 'react-router-dom';
+import { message } from 'antd';
+import { getThirdpartySimConfig } from '../../utils/getConfig'
+import "./dfsp-sim.css";
+
+class DFSPAuthorize extends React.Component {
+
+  constructor () {
+    super()
+    this.state = {
+      userName: '',
+      password: '',
+      consentRequestId: '',
+      callbackUri: ''
+    }
+  }
+
+  validateForm = () => {
+    return this.state.userName.length > 0 && this.state.password.length > 0;
+  }
+
+  loginUser = async () => {
+    try {
+      const consentRequestId = (queryString.parse(this.props.location.search)).consentRequestId;
+      const callbackUri = (queryString.parse(this.props.location.search)).callbackUri;
+      this.setState({ consentRequestId: consentRequestId, callbackUri: callbackUri });
+      const forwrdUri = "/admin/dfsp/grant-user-consent" + (this.props.location.search || '');
+      const { thirdpartySimAPIBaseUrl } = await getThirdpartySimConfig();
+      const loginURL = thirdpartySimAPIBaseUrl + '/login';
+      const res = await axios.post(loginURL, {
+        userName: this.state.userName,
+        password: this.state.password
+      }, { headers: { 'Content-Type': 'application/json' } });
+      if (res.status == 200) {
+        message.success({ content: 'login successful', key: 'login', duration: 3 });
+        this.props.history.push(forwrdUri);
+      } else {
+        window.location.href = (this.state.callbackUri) + '?status=rejected&consentRequestId=' + this.state.consentRequestId;
+      }
+      return
+    } catch (error) {
+      window.location.href = (this.state.callbackUri) + '?status=rejected&consentRequestId=' + this.state.consentRequestId;
+      return
+    }
+  }
+
+  handleSubmit = async (e) => {
+    e.preventDefault()
+    this.validateForm()
+    await this.loginUser()
+  }
+
+  render () {
+    return (
+      <div className="login__wrapper" >
+        <form className="auth__form" onSubmit={async e => { await this.handleSubmit(e) }}>
+          <h5>Please Login</h5>
+          <label className="auth__form__username">
+            User Name : &nbsp;&nbsp;
+            <input type="text" name="userName" value={this.state.userName} onChange={e => this.setState({ userName: e.target.value })} />
+          </label>
+          <label className="auth__form__password">
+            Password : &nbsp;&nbsp;&nbsp;&nbsp;
+            <input type="password" name="password" value={this.state.password} onChange={e => this.setState({ password: e.target.value })} />
+          </label>
+          <div>
+            <button className="auth__form__submit__btn" type="submit" disabled={!this.validateForm()}>Login</button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+}
+
+export default withRouter(DFSPAuthorize)

--- a/src/views/thirdparty-simulator/DFSPGrantConsent.jsx
+++ b/src/views/thirdparty-simulator/DFSPGrantConsent.jsx
@@ -1,0 +1,140 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+import React from 'react';
+import axios from 'axios';
+import queryString from 'query-string';
+import { Select, Radio, message } from 'antd';
+import { getThirdpartySimConfig } from '../../utils/getConfig'
+import "./dfsp-sim.css";
+
+const { Option } = Select
+
+class GrantConsent extends React.Component {
+
+  constructor () {
+    super()
+    this.state = {
+      selectOptions: [],
+      value: [],
+      consentStatus: '',
+      consentRequestId: '',
+      callbackUri: ''
+    }
+  }
+
+  componentDidMount = async () => {
+    await this.getOptions();
+  }
+  getOptions = async () => {
+    const consentRequestId = (queryString.parse(this.props.location.search)).consentRequestId;
+    const callbackUri = (queryString.parse(this.props.location.search)).callbackUri;
+    this.setState({ consentRequestId: consentRequestId, callbackUri: callbackUri });
+    const { thirdpartySimAPIBaseUrl } = await getThirdpartySimConfig();
+    const consentURL = thirdpartySimAPIBaseUrl + '/store/consentRequests/' + consentRequestId;
+    const res = await axios.get(consentURL, { headers: { 'Content-Type': 'application/json' } })
+    const dataStr = (res.data.value).replace(/\'/gi, '\"')
+    const options = (JSON.parse(dataStr)).scopes.map(d => ({
+      "value": d.accountId,
+      "text": d.accountId
+    }))
+    this.setState({ selectOptions: options })
+  }
+
+  handleChange = async (value) => {
+    this.setState({ value: value })
+  }
+
+  validateForm = () => {
+    return this.state.value.length > 0 && this.state.consentStatus.length > 0;
+  }
+
+  grantConsent = async () => {
+    try {
+      let forwardUri;
+      if (this.state.consentStatus == 'true') {
+        const { thirdpartySimAPIBaseUrl } = await getThirdpartySimConfig();
+        const authorizeUri = thirdpartySimAPIBaseUrl + '/authorize';
+        const res = await axios.post(authorizeUri, {
+          userId: this.state.value,
+          consentRequestId: this.state.consentRequestId
+        }, { headers: { 'Content-Type': 'application/json' } });
+        if (res.status == 200) {
+          message.success({ content: 'authorization successful', key: 'authorization', duration: 3 });
+          forwardUri = (this.state.callbackUri) + '?status=approved&consentRequestId=' + this.state.consentRequestId + '&secret=' + res.data.secret;
+        }
+        else {
+          forwardUri = (this.state.callbackUri) + '?status=rejected&consentRequestId=' + this.state.consentRequestId;
+        }
+      } else {
+        forwardUri = (this.state.callbackUri) + '?status=rejected&consentRequestId=' + this.state.consentRequestId;
+      }
+      window.location.href = forwardUri;
+      return
+    } catch (error) {
+      window.location.href = (this.state.callbackUri) + '?status=rejected&consentRequestId=' + this.state.consentRequestId;
+      return
+    }
+  }
+
+  handleSubmit = async (e) => {
+    e.preventDefault()
+    this.validateForm()
+    await this.grantConsent()
+  }
+
+  render () {
+    const options = this.state.selectOptions.map(d => <Option key={d.value}>{d.text}</Option>);
+    return (
+      <div className="login__wrapper" >
+        <form className="auth__form" onSubmit={async e => { await this.handleSubmit(e) }}>
+          <h4>Grant consent</h4>
+          <label className="auth__form__username">
+            Accounts : &nbsp;&nbsp;
+          <Select
+              mode="multiple"
+              allowClear
+              style={{ width: 200 }}
+              value={this.state.value}
+              placeholder="Select Accounts to link"
+              onChange={this.handleChange}>
+              {options}
+            </Select>
+          </label>
+          <label className="auth__form__username">
+            Consent : &nbsp;&nbsp;
+        <Radio.Group
+              value={this.state.consentStatus}
+              onChange={e => this.setState({ consentStatus: e.target.value })}>
+              <Radio value={'true'}>Approve</Radio>
+              <Radio value={'false'}>Reject</Radio>
+            </Radio.Group>
+          </label>
+          <button className="auth__form__submit__btn" type="submit" disabled={!this.validateForm()}>Submit</button>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default GrantConsent

--- a/src/views/thirdparty-simulator/dfsp-sim.css
+++ b/src/views/thirdparty-simulator/dfsp-sim.css
@@ -1,0 +1,31 @@
+.auth {
+  background: #303460;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.auth__form {
+  width: 420px;
+  background: #f8f8f8;
+  padding: 20px;
+  flex: 0 0 auto;
+  border: 2px solid #eee;
+  animation: fadeInAuthForm 0.5s ease-out 1 forwards;
+
+}
+.auth__form__username {
+  margin-bottom: 20px;
+}
+.auth__form__password {
+  margin-bottom: 20px;
+}
+
+.auth__form__submit__btn {
+  background: #303460;
+  width: 200px;
+  color: white;
+  font-weight: bold;
+}


### PR DESCRIPTION
Closes [ #1984](https://github.com/mojaloop/project/issues/1984)

- [x] Implement the following screens that will connect to the mock dfsp login API (in TTK)
    - [x] login
    - [x] select accounts for linking
    - [x] approve\reject and redirect
- [x] connect these screens with the mock dfsp login back-end