### PR TITLE
Feature/Make build and start commands to be able to use node 17 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://localhost:6060/",
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts --max_old_space_size=4096 build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --max_old_space_size=4096 --openssl-legacy-provider build",
     "test:react": "react-scripts test",
     "eject": "react-scripts eject",
     "install:clean": "rm -rf node_modules/ && rm -rf package-lock.json && npm install && npm start",


### PR DESCRIPTION
- added --openssl-legacy-provider to start and build commands to be able to use node 17 and higher
- tried fixing it by upgrading react-scripts and its peer dependencies but there were a few breaking changes that required ejecting the app or adding some sort of a wrapper, so added this flag for now (should be look at as a temporary solution)